### PR TITLE
Fix panic due to sync.WaitGroup misuse

### DIFF
--- a/main.go
+++ b/main.go
@@ -423,6 +423,7 @@ func phaseRunnerA(phase string, id int64, val int64, payloadChan chan Payload) {
 				}
 				if counter > majority {
 					wg.Done()
+					return
 				}
 			case <-time.After(BigTimeout):
 				// don't leak the goroutine


### PR DESCRIPTION
Fixes the following panic

```
http: panic serving [::1]:60665: sync: WaitGroup is reused before previous Wait has returned
```

Detailed panic info here: https://gist.github.com/vaskoz/795cef5ae0cadd532e11
